### PR TITLE
NIFI-4698 - Check email attribute from oidc response. If no email, use upn value …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/StandardOidcIdentityProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/StandardOidcIdentityProvider.java
@@ -345,13 +345,18 @@ public class StandardOidcIdentityProvider implements OidcIdentityProvider {
                     claimsSet = successResponse.getUserInfoJWT().getJWTClaimsSet();
                 }
 
-                final String email = claimsSet.getStringClaim(EMAIL_CLAIM_NAME);
 
+                final String email = claimsSet.getStringClaim(EMAIL_CLAIM_NAME);
+                // Workaround : Azure AD response returns email address as "upn" instead of "email"
+                // If email is not in response, check for upn
+                final String ad_upn = claimsSet.getStringClaim("upn");
                 // ensure we were able to get the user email
-                if (StringUtils.isBlank(email)) {
+                if (StringUtils.isBlank(email) && StringUtils.isBlank(ad_upn)) {
                     throw new IllegalStateException("Unable to extract email from the UserInfo token.");
-                } else {
+                } else if (!StringUtils.isBlank(email)){
                     return email;
+                } else{
+                    return ad_upn;
                 }
             } else {
                 final UserInfoErrorResponse errorResponse = (UserInfoErrorResponse) response;


### PR DESCRIPTION
Submitted code change for Nifi-AzureAD email issue. The community feedback is to make further changes. This commit is internal to hashmap nifi code base.